### PR TITLE
Fix for home page feed not being scrollable

### DIFF
--- a/lib/pages/home_page/home_page.dart
+++ b/lib/pages/home_page/home_page.dart
@@ -7,28 +7,29 @@ class HomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      child: ListView(
-        // padding: const EdgeInsets.symmetric(horizontal: 16.0),
-        shrinkWrap: true,
-        children: [
-          const UserProfile(),
-          const SizedBox(height: 24),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Text(
-              "Recipes",
-              style: Theme.of(context).textTheme.titleLarge,
+    return CustomScrollView(
+      slivers: [
+        // Top section of homepage
+        SliverList.list(
+          children: [
+            const UserProfile(),
+            const SizedBox(height: 24),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Text(
+                "Recipes",
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
             ),
-          ),
-          const SizedBox(height: 16),
-          const Padding(
-            padding: EdgeInsets.symmetric(horizontal: 16),
-            child: RecipeFeed(),
-          ),
-          const SizedBox(height: 24),
-        ],
-      ),
+          ],
+        ),
+        const SliverPadding(
+          padding: EdgeInsets.fromLTRB(12, 12, 12, 24),
+
+          // Displays a grid for all recipes
+          sliver: RecipeFeed(),
+        ),
+      ],
     );
   }
 }

--- a/lib/pages/home_page/home_widgets/recipe_feed.dart
+++ b/lib/pages/home_page/home_widgets/recipe_feed.dart
@@ -21,37 +21,37 @@ class _RecipeFeedState extends State<RecipeFeed> {
     return StreamBuilder<QuerySnapshot>(
       stream: recipeStream,
       builder: (context, snapshot) {
-        List<Widget> recipeWidgets = [];
-
         if (snapshot.hasError ||
             snapshot.connectionState == ConnectionState.waiting) {
-          return const Center(
+          return const SliverToBoxAdapter(
+            child: Center(
               child: CircularProgressIndicator(
-            color: AppColors.yellowTheme,
-          ));
+                color: AppColors.yellowTheme,
+              ),
+            ),
+          );
         } else if (snapshot.hasData || snapshot.data != null) {
-          final recipeDocs = snapshot.data?.docs.reversed.toList();
-
-          for (var recipeDoc in recipeDocs!) {
-            final String documentId = recipeDoc.id;
-            final recipeWidget = RecipeFeedItem(
-              name: recipeDoc['name'].toString(),
-              imageUrl: recipeDoc['image'].toString(),
-              ingredients: recipeDoc['ingredients'].toString(),
-              process: recipeDoc['process'].toString(),
-              calories: recipeDoc['calories'],
-              documentId: documentId,
-            );
-            recipeWidgets.add(recipeWidget);
-          }
+          return SliverGrid.builder(
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              crossAxisSpacing: 16,
+              mainAxisSpacing: 24,
+            ),
+            itemCount: snapshot.data!.docs.length,
+            itemBuilder: (context, index) {
+              return RecipeFeedItem.fromDocumentSnapshot(
+                snapshot.data!.docs[index],
+              );
+            },
+          );
+        } else {
+          // Finished fetching but snapshot has no data
+          return const SliverToBoxAdapter(
+            child: Center(
+              child: Text("No recipes available"),
+            ),
+          );
         }
-        return GridView.count(
-          shrinkWrap: true,
-          mainAxisSpacing: 24,
-          crossAxisSpacing: 16,
-          crossAxisCount: 2,
-          children: recipeWidgets,
-        );
       },
     );
   }

--- a/lib/pages/home_page/home_widgets/recipe_feed_item.dart
+++ b/lib/pages/home_page/home_widgets/recipe_feed_item.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flilipino_food_app/pages/home_page/home_widgets/display_recipe.dart';
 import 'package:flutter/material.dart';
 
@@ -81,7 +82,17 @@ class RecipeFeedItem extends StatelessWidget {
           ),
         ),
       ),
-      // OldRecipeItem(imageUrl: imageUrl, name: name, calories: calories, userCalorieLimit: userCalorieLimit, provider: provider, documentId: documentId, ingredients: ingredients, process: process),
+    );
+  }
+
+  factory RecipeFeedItem.fromDocumentSnapshot(QueryDocumentSnapshot recipeDoc) {
+    return RecipeFeedItem(
+      name: recipeDoc['name'].toString(),
+      imageUrl: recipeDoc['image'].toString(),
+      ingredients: recipeDoc['ingredients'].toString(),
+      process: recipeDoc['process'].toString(),
+      calories: recipeDoc['calories'],
+      documentId: recipeDoc.id,
     );
   }
 }


### PR DESCRIPTION
Closes #29 .

Bugfix for not being able to scroll the home page correctly in mobile due to incorrect placement of layout widgets. Used CustomScrollView instead to allow stacking of multiple scrollables. GridView and ListView were converted to their corresponding SliverList alternatives.

Other changes:

- Corrected the implementation of the GridView builder
  - Instead of iterating through snapshot and feeding a list of Widgets to the GridView, used builder method with an itemBuilder
- Added factory method in RecipeFeedItem for converting from a QueryDocumentSnapshot.